### PR TITLE
fix userPayload variable

### DIFF
--- a/export-voters/index.ts
+++ b/export-voters/index.ts
@@ -45,8 +45,8 @@ Deno.serve(async (req: Request) => {
     // verify JWT provided by the user
     try {
         const ecPublicKey = await jose.importSPKI(key, 'RS256');
-        const { payload: userPayload } = await jose.jwtVerify(jwt, ecPublicKey);
-
+        const { payload: { user: userPayload } } = await jose.jwtVerify(jwt, ecPublicKey);
+        
         if (!userPayload.adminPrivileges) {
             return new Response(
                 JSON.stringify({


### PR DESCRIPTION
the `userPayload` variable looked like this:

```
{
  user: {
    firstName: "Abir",
    lastName: "Taheer",
    email: "ataheer10@stuy.edu",
    adminPrivileges: true
  },
  iat: 1731513591
}
```

that's why `userPayload.adminPrivileges` was not true